### PR TITLE
Added QosComponent

### DIFF
--- a/Blaze3SDK/Component.cs
+++ b/Blaze3SDK/Component.cs
@@ -15,6 +15,7 @@
         LeagueComponent = 13,
         MailComponent = 14,
         MessagingComponent = 15,
+        QosComponent = 16,
         LockerComponent = 20,
         RoomsComponent = 21,
         TournamentsComponent = 23,


### PR DESCRIPTION
Found this component while researching the QoS servers, not too sure what the individual command IDs are but their names are Qos, Firewall, and FireType. Have only seen it accessed through the HTTP version of blaze through games like Mass Effect 3, and Mass Effect Andromeda

(See component in the attached error message screenshot)

![image](https://github.com/Aim4kill/BlazeSDK/assets/33708767/35707e07-4911-4b26-8f1a-317901fdc10d)
![image](https://github.com/Aim4kill/BlazeSDK/assets/33708767/1bfb3b61-1749-40a5-aeae-d0650b8214af)
![image](https://github.com/Aim4kill/BlazeSDK/assets/33708767/8b7a3c1c-ade4-4035-a117-276a37a41c2b)
![image](https://github.com/Aim4kill/BlazeSDK/assets/33708767/0dfc5a23-61ea-4a0e-8cee-2527f4feb175)
